### PR TITLE
Add MatchState to store real match and alliance color

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -64,18 +64,7 @@ public class Robot extends TimedRobot {
       m_autonomousCommand.schedule();
     }
 
-    boolean realMatch = DriverStation.getMatchTime() > 1.0;
-    m_robotContainer.matchState.realMatch = realMatch;
-    // boolean blue = DriverStation.getAlliance() == DriverStation.Alliance.Blue;
-    if (!DriverStation.getAlliance().isEmpty()) {
-      boolean blue;
-      if (!realMatch) {
-        blue = true;
-      } else {
-        blue = DriverStation.getAlliance().get() == DriverStation.Alliance.Blue;
-      }
-      m_robotContainer.matchState.blue = blue;
-    }
+    setRobotContainerMatchState();
   }
 
   /** This function is called periodically during autonomous. */
@@ -92,18 +81,7 @@ public class Robot extends TimedRobot {
       m_autonomousCommand.cancel();
     }
 
-    boolean realMatch = DriverStation.getMatchTime() > 1.0;
-    m_robotContainer.matchState.realMatch = realMatch;
-    // boolean blue = DriverStation.getAlliance() == DriverStation.Alliance.Blue;
-    if (!DriverStation.getAlliance().isEmpty()) {
-      boolean blue;
-      if (!realMatch) {
-        blue = true;
-      } else {
-        blue = DriverStation.getAlliance().get() == DriverStation.Alliance.Blue;
-      }
-      m_robotContainer.matchState.blue = blue;
-    }
+    setRobotContainerMatchState();
   }
 
   /** This function is called periodically during operator control. */
@@ -127,4 +105,18 @@ public class Robot extends TimedRobot {
   /** This function is called periodically whilst in simulation. */
   @Override
   public void simulationPeriodic() {}
+
+  private void setRobotContainerMatchState() {
+    boolean realMatch = DriverStation.getMatchTime() > 1.0;
+    m_robotContainer.matchState.realMatch = realMatch;
+    if (!DriverStation.getAlliance().isEmpty()) {
+      boolean blue;
+      if (!realMatch) {
+        blue = true;
+      } else {
+        blue = DriverStation.getAlliance().get() == DriverStation.Alliance.Blue;
+      }
+      m_robotContainer.matchState.blue = blue;
+    }
+  }
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,6 +4,7 @@
 
 package frc.robot;
 
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
@@ -62,6 +63,19 @@ public class Robot extends TimedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.schedule();
     }
+
+    boolean realMatch = DriverStation.getMatchTime() > 1.0;
+    m_robotContainer.matchState.realMatch = realMatch;
+    // boolean blue = DriverStation.getAlliance() == DriverStation.Alliance.Blue;
+    if (!DriverStation.getAlliance().isEmpty()) {
+      boolean blue;
+      if (!realMatch) {
+        blue = true;
+      } else {
+        blue = DriverStation.getAlliance().get() == DriverStation.Alliance.Blue;
+      }
+      m_robotContainer.matchState.blue = blue;
+    }
   }
 
   /** This function is called periodically during autonomous. */
@@ -76,6 +90,19 @@ public class Robot extends TimedRobot {
     // this line or comment it out.
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
+    }
+
+    boolean realMatch = DriverStation.getMatchTime() > 1.0;
+    m_robotContainer.matchState.realMatch = realMatch;
+    // boolean blue = DriverStation.getAlliance() == DriverStation.Alliance.Blue;
+    if (!DriverStation.getAlliance().isEmpty()) {
+      boolean blue;
+      if (!realMatch) {
+        blue = true;
+      } else {
+        blue = DriverStation.getAlliance().get() == DriverStation.Alliance.Blue;
+      }
+      m_robotContainer.matchState.blue = blue;
     }
   }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -109,14 +109,16 @@ public class Robot extends TimedRobot {
   private void setRobotContainerMatchState() {
     boolean realMatch = DriverStation.getMatchTime() > 1.0;
     m_robotContainer.matchState.realMatch = realMatch;
-    if (!DriverStation.getAlliance().isEmpty()) {
+    if (DriverStation.getAlliance().isPresent()) {
       boolean blue;
-      if (!realMatch) {
-        blue = true;
-      } else {
+      if (realMatch) {
         blue = DriverStation.getAlliance().get() == DriverStation.Alliance.Blue;
+      } else {
+        blue = true;
       }
       m_robotContainer.matchState.blue = blue;
+    } else {
+      m_robotContainer.matchState.blue = true;
     }
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -32,6 +32,15 @@ public class RobotContainer {
     configureBindings();
   }
 
+  /**
+   * This class stores the state of the match (the alliance color, and whether it's a real match)
+   *
+   * @param realMatch a boolean variable defining whether we are in a real match; this can be
+   *     determined by checking if the remaining match time in the init function for the match face
+   *     is greater than one second
+   * @param blue a boolean variable defining whether we are on the blue alliance (true) or the red
+   *     alliance (false). When in a fake match, this variable should be true.
+   */
   public class MatchState {
     public boolean realMatch;
     public boolean blue;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -32,6 +32,18 @@ public class RobotContainer {
     configureBindings();
   }
 
+  public class MatchState {
+    public boolean realMatch;
+    public boolean blue;
+
+    public MatchState(boolean realMatch, boolean blue) {
+      this.realMatch = realMatch;
+      this.blue = blue;
+    }
+  }
+
+  public MatchState matchState = new MatchState(false, true);
+
   /**
    * Use this method to define your trigger->command mappings. Triggers can be created via the
    * {@link Trigger#Trigger(java.util.function.BooleanSupplier)} constructor with an arbitrary

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -28,13 +28,12 @@ import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
-import frc.robot.RobotMap;
 import frc.robot.RobotContainer.MatchState;
+import frc.robot.RobotMap;
 import frc.robot.subsystems.Lights;
 import frc.robot.utils.GeometryUtils;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BooleanSupplier;
 
 public class DriveSubsystem extends SubsystemBase {
   private double targetHeadingDegrees;

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -242,7 +242,7 @@ public class DriveSubsystem extends SubsystemBase {
     ChassisSpeeds desiredChassisSpeeds =
         fieldRelative
             ? ChassisSpeeds.fromFieldRelativeSpeeds(
-                xSpeed, ySpeed, rot, Rotation2d.fromDegrees(gyro.getYaw().getValue()))
+                matchState.blue ? xSpeed : -xSpeed, ySpeed, rot, Rotation2d.fromDegrees(gyro.getYaw().getValue()))
             : new ChassisSpeeds(xSpeed, ySpeed, rot);
 
     desiredChassisSpeeds = correctForDynamics(desiredChassisSpeeds);

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -28,12 +28,13 @@ import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
-import frc.robot.RobotContainer.MatchState;
 import frc.robot.RobotMap;
+import frc.robot.RobotContainer.MatchState;
 import frc.robot.subsystems.Lights;
 import frc.robot.utils.GeometryUtils;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BooleanSupplier;
 
 public class DriveSubsystem extends SubsystemBase {
   private double targetHeadingDegrees;
@@ -241,10 +242,7 @@ public class DriveSubsystem extends SubsystemBase {
     ChassisSpeeds desiredChassisSpeeds =
         fieldRelative
             ? ChassisSpeeds.fromFieldRelativeSpeeds(
-                matchState.blue ? xSpeed : -xSpeed,
-                matchState.blue ? ySpeed : -ySpeed,
-                rot,
-                Rotation2d.fromDegrees(gyro.getYaw().getValue()))
+                matchState.blue ? xSpeed : -xSpeed, ySpeed, rot, Rotation2d.fromDegrees(gyro.getYaw().getValue()))
             : new ChassisSpeeds(xSpeed, ySpeed, rot);
 
     desiredChassisSpeeds = correctForDynamics(desiredChassisSpeeds);

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -163,18 +163,18 @@ public class DriveSubsystem extends SubsystemBase {
   public void resetOdometry(Pose2d pose) {
     // Just update the translation, not the yaw
     Pose2d resetPose =
-        new Pose2d(pose.getTranslation(), Rotation2d.fromDegrees(gyro.getYaw().getValue()));
-    odometry.resetPosition(
-        Rotation2d.fromDegrees(gyro.getYaw().getValue()), getModulePositions(), resetPose);
+        new Pose2d(
+            pose.getTranslation(),
+            Rotation2d.fromDegrees(gyro.getYaw().getValue() + (matchState.blue ? 0 : 180)));
+    odometry.resetPosition(resetPose.getRotation(), getModulePositions(), resetPose);
   }
 
   public void resetYawToAngle(double yawDeg) {
-    double curYawDeg = gyro.getYaw().getValue();
+    double curYawDeg = gyro.getYaw().getValue() + (matchState.blue ? 0 : 180);
     double offsetToTargetDeg = targetHeadingDegrees - curYawDeg;
     gyro.setYaw(yawDeg);
     Pose2d curPose = getPose();
-    Pose2d resetPose = new Pose2d(curPose.getTranslation(), Rotation2d.fromDegrees(yawDeg));
-    odometry.resetPosition(Rotation2d.fromDegrees(yawDeg), getModulePositions(), resetPose);
+    resetOdometry(curPose);
     targetHeadingDegrees = yawDeg + offsetToTargetDeg;
   }
 
@@ -288,10 +288,10 @@ public class DriveSubsystem extends SubsystemBase {
   /**
    * Returns the heading of the robot.
    *
-   * @return the robot's heading in degrees, from -180 to 180
+   * @return the robot's heading in degrees, from -180 to 180 (field relative, so 0 is facing away from blue)
    */
   public double getHeadingDegrees() {
-    return Rotation2d.fromDegrees(gyro.getYaw().getValue()).getDegrees();
+    return Rotation2d.fromDegrees(gyro.getYaw().getValue()).getDegrees() + (matchState.blue ? 0 : 180);
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -29,6 +29,7 @@ import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.RobotMap;
+import frc.robot.RobotContainer.MatchState;
 import frc.robot.subsystems.Lights;
 import frc.robot.utils.GeometryUtils;
 import java.util.List;
@@ -77,9 +78,9 @@ public class DriveSubsystem extends SubsystemBase {
   /** Multiplier for drive speed, does not affect trajectory following */
   private double throttleMultiplier = 1.0;
 
-  private BooleanSupplier isTimedMatch;
+  private MatchState matchState;
 
-  public DriveSubsystem(Lights lightsSubsystem, BooleanSupplier isTimedMatchFunc) {
+  public DriveSubsystem(Lights lightsSubsystem, MatchState matchState) {
     Pigeon2Configurator cfg = gyro.getConfigurator();
     Pigeon2Configuration blankGyroConfiguration = new Pigeon2Configuration();
     cfg.apply(blankGyroConfiguration);
@@ -93,7 +94,7 @@ public class DriveSubsystem extends SubsystemBase {
     cfg.apply(gyroConfig);
 
     this.lights = lightsSubsystem;
-    this.isTimedMatch = isTimedMatchFunc;
+    this.matchState = matchState;
   }
 
   @Override
@@ -500,8 +501,8 @@ public class DriveSubsystem extends SubsystemBase {
     targetHeadingDegrees = getHeadingDegrees() + offsetDegrees;
   }
 
-  public void setZeroTargetHeading() {
-    targetHeadingDegrees = 0.0;
+  public void setForwardTargetHeading() {
+    targetHeadingDegrees = matchState.blue ? 0 : 180;
   }
 
   public void stopDriving() {

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -163,18 +163,18 @@ public class DriveSubsystem extends SubsystemBase {
   public void resetOdometry(Pose2d pose) {
     // Just update the translation, not the yaw
     Pose2d resetPose =
-        new Pose2d(
-            pose.getTranslation(),
-            Rotation2d.fromDegrees(gyro.getYaw().getValue() + (matchState.blue ? 0 : 180)));
-    odometry.resetPosition(resetPose.getRotation(), getModulePositions(), resetPose);
+        new Pose2d(pose.getTranslation(), Rotation2d.fromDegrees(gyro.getYaw().getValue()));
+    odometry.resetPosition(
+        Rotation2d.fromDegrees(gyro.getYaw().getValue()), getModulePositions(), resetPose);
   }
 
   public void resetYawToAngle(double yawDeg) {
-    double curYawDeg = gyro.getYaw().getValue() + (matchState.blue ? 0 : 180);
+    double curYawDeg = gyro.getYaw().getValue();
     double offsetToTargetDeg = targetHeadingDegrees - curYawDeg;
     gyro.setYaw(yawDeg);
     Pose2d curPose = getPose();
-    resetOdometry(curPose);
+    Pose2d resetPose = new Pose2d(curPose.getTranslation(), Rotation2d.fromDegrees(yawDeg));
+    odometry.resetPosition(Rotation2d.fromDegrees(yawDeg), getModulePositions(), resetPose);
     targetHeadingDegrees = yawDeg + offsetToTargetDeg;
   }
 
@@ -288,10 +288,10 @@ public class DriveSubsystem extends SubsystemBase {
   /**
    * Returns the heading of the robot.
    *
-   * @return the robot's heading in degrees, from -180 to 180 (field relative, so 0 is facing away from blue)
+   * @return the robot's heading in degrees, from -180 to 180
    */
   public double getHeadingDegrees() {
-    return Rotation2d.fromDegrees(gyro.getYaw().getValue()).getDegrees() + (matchState.blue ? 0 : 180);
+    return Rotation2d.fromDegrees(gyro.getYaw().getValue()).getDegrees();
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -28,13 +28,12 @@ import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
-import frc.robot.RobotMap;
 import frc.robot.RobotContainer.MatchState;
+import frc.robot.RobotMap;
 import frc.robot.subsystems.Lights;
 import frc.robot.utils.GeometryUtils;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BooleanSupplier;
 
 public class DriveSubsystem extends SubsystemBase {
   private double targetHeadingDegrees;
@@ -242,7 +241,10 @@ public class DriveSubsystem extends SubsystemBase {
     ChassisSpeeds desiredChassisSpeeds =
         fieldRelative
             ? ChassisSpeeds.fromFieldRelativeSpeeds(
-                matchState.blue ? xSpeed : -xSpeed, ySpeed, rot, Rotation2d.fromDegrees(gyro.getYaw().getValue()))
+                matchState.blue ? xSpeed : -xSpeed,
+                matchState.blue ? ySpeed : -ySpeed,
+                rot,
+                Rotation2d.fromDegrees(gyro.getYaw().getValue()))
             : new ChassisSpeeds(xSpeed, ySpeed, rot);
 
     desiredChassisSpeeds = correctForDynamics(desiredChassisSpeeds);

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -242,7 +242,7 @@ public class DriveSubsystem extends SubsystemBase {
     ChassisSpeeds desiredChassisSpeeds =
         fieldRelative
             ? ChassisSpeeds.fromFieldRelativeSpeeds(
-                matchState.blue ? xSpeed : -xSpeed, ySpeed, rot, Rotation2d.fromDegrees(gyro.getYaw().getValue()))
+                xSpeed, ySpeed, rot, Rotation2d.fromDegrees(gyro.getYaw().getValue()))
             : new ChassisSpeeds(xSpeed, ySpeed, rot);
 
     desiredChassisSpeeds = correctForDynamics(desiredChassisSpeeds);


### PR DESCRIPTION
This commit adds match state tracking to the RobotContainer class, which includes a boolean flag for whether it is a real match and another boolean flag for the alliance color. The Robot class now updates the match state based on the DriverStation information. Additionally, in the DriveSubsystem class, the target heading is set to either 0 or 180 degrees depending on the alliance color.

^^ ai generated lmao