### PR TITLE
Add Interrupt Handling Feature to the Command Groups

### DIFF
--- a/src/main/java/frc/robot/commands/AmpPrepScore.java
+++ b/src/main/java/frc/robot/commands/AmpPrepScore.java
@@ -18,7 +18,7 @@ import frc.robot.subsystems.shooter.Shooter;
  */
 public class AmpPrepScore extends SequentialCommandGroup {
   /** Creates a new AmpPreScore. */
-  public AmpPrepScore(Elevator elevator, Intake intake) {
+  public AmpPrepScore(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
     addRequirements(elevator, intake);
 
     SequentialCommandGroup moveWhenNotSafe =
@@ -41,9 +41,13 @@ public class AmpPrepScore extends SequentialCommandGroup {
             }));
   }
 
-  /** runs AmpPrepScore but adds the layer that if the robot is interrupted, then everything is brought to the home state */
-  public static Command interruptibleAmpPrepScore(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
-    return new AmpPrepScore(elevator, intake)
+  /**
+   * runs AmpPrepScore but adds the layer that if the robot is interrupted, then everything is
+   * brought to the home state
+   */
+  public static Command interruptibleAmpPrepScore(
+      Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
+    return new AmpPrepScore(intake, elevator, conveyor, shooter)
         .finallyDo(
             (boolean interrupted) -> {
               new StopMostThings(intake, elevator, conveyor, shooter);

--- a/src/main/java/frc/robot/commands/AmpPrepScore.java
+++ b/src/main/java/frc/robot/commands/AmpPrepScore.java
@@ -1,5 +1,6 @@
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.ConditionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
@@ -9,15 +10,16 @@ import frc.robot.subsystems.elevator.Elevator;
 import frc.robot.subsystems.elevator.Elevator.ElevatorPosition;
 import frc.robot.subsystems.intake.Intake;
 import frc.robot.subsystems.intake.Intake.IntakePosition;
+import frc.robot.subsystems.shooter.Shooter;
 
 /**
- * Prepares to score in the amp. This command group safely moves the conveyor and elevator to the
+ * Prepares to score in the amp. This command group safely moves the intake and elevator to the
  * score amp position.
  */
 public class AmpPrepScore extends SequentialCommandGroup {
   /** Creates a new AmpPreScore. */
-  public AmpPrepScore(Elevator elevator, Conveyor conveyer, Intake intake) {
-    addRequirements(conveyer, elevator, intake);
+  public AmpPrepScore(Elevator elevator, Intake intake) {
+    addRequirements(elevator, intake);
 
     SequentialCommandGroup moveWhenNotSafe =
         new SequentialCommandGroup(
@@ -37,5 +39,14 @@ public class AmpPrepScore extends SequentialCommandGroup {
             () -> {
               return intake.atDesiredIntakePosition() && elevator.atDesiredPosition();
             }));
+  }
+
+  /** runs AmpPrepScore but adds the layer that if the robot is interrupted, then everything is brought to the home state */
+  public static Command interruptibleAmpPrepScore(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
+    return new AmpPrepScore(elevator, intake)
+        .finallyDo(
+            (boolean interrupted) -> {
+              new StopMostThings(intake, elevator, conveyor, shooter);
+            });
   }
 }

--- a/src/main/java/frc/robot/commands/AmpScore.java
+++ b/src/main/java/frc/robot/commands/AmpScore.java
@@ -1,7 +1,11 @@
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.subsystems.conveyor.Conveyor;
+import frc.robot.subsystems.elevator.Elevator;
+import frc.robot.subsystems.intake.Intake;
+import frc.robot.subsystems.shooter.Shooter;
 
 /**
  * Scores a note in the amp. At the moment, this only calls the scoreTrapOrAmp command in the
@@ -15,5 +19,14 @@ public class AmpScore extends SequentialCommandGroup {
         Conveyor.scoreTrapOrAmp(conveyor)
         // TODO "smartly" go home (e.g. go home once we've driven away from the wall)
         );
+  }
+
+  /** runs AmpScore but adds the layer that if the robot is interrupted, then everything is brought back to the prep state */
+  public static Command interruptibleAmpScore(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
+    return new AmpScore(conveyor)
+        .finallyDo(
+            (boolean interrupted) -> {
+              AmpPrepScore.interruptibleAmpPrepScore(intake, elevator, conveyor, shooter);
+            });
   }
 }

--- a/src/main/java/frc/robot/commands/AmpScore.java
+++ b/src/main/java/frc/robot/commands/AmpScore.java
@@ -13,7 +13,7 @@ import frc.robot.subsystems.shooter.Shooter;
  * we will likely want a separate command group.
  */
 public class AmpScore extends SequentialCommandGroup {
-  public AmpScore(Conveyor conveyor) {
+  public AmpScore(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
     addRequirements(conveyor);
     addCommands(
         Conveyor.scoreTrapOrAmp(conveyor)
@@ -23,7 +23,7 @@ public class AmpScore extends SequentialCommandGroup {
 
   /** runs AmpScore but adds the layer that if the robot is interrupted, then everything is brought back to the prep state */
   public static Command interruptibleAmpScore(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
-    return new AmpScore(conveyor)
+    return new AmpScore(intake, elevator, conveyor, shooter)
         .finallyDo(
             (boolean interrupted) -> {
               AmpPrepScore.interruptibleAmpPrepScore(intake, elevator, conveyor, shooter);

--- a/src/main/java/frc/robot/commands/ClimbSequence.java
+++ b/src/main/java/frc/robot/commands/ClimbSequence.java
@@ -1,5 +1,6 @@
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
@@ -33,4 +34,14 @@ public class ClimbSequence extends SequentialCommandGroup {
         new WaitUntilCommand(elevator::atDesiredPosition),
         Conveyor.scoreTrapOrAmp(conveyor));
   }
+
+  /** runs ClimbSequence but adds the layer that if the robot is interrupted, then everything is brought to the prep state */
+  public static Command interruptibleClimbSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
+    return new ClimbSequence(intake, elevator, shooter, conveyor)
+        .finallyDo(
+            (boolean interrupted) -> {
+              PrepClimbSequence.interruptiblePrepClimbSequence(intake, elevator, conveyor, shooter);
+            });
+  }
+
 }

--- a/src/main/java/frc/robot/commands/ClimbSequence.java
+++ b/src/main/java/frc/robot/commands/ClimbSequence.java
@@ -16,7 +16,7 @@ import frc.robot.subsystems.shooter.Shooter.ShooterMode;
  * the trap
  */
 public class ClimbSequence extends SequentialCommandGroup {
-  public ClimbSequence(Intake intake, Elevator elevator, Shooter shooter, Conveyor conveyor) {
+  public ClimbSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
     addRequirements(intake, elevator, shooter, conveyor);
     addCommands(
         new WaitUntilCommand(
@@ -37,7 +37,7 @@ public class ClimbSequence extends SequentialCommandGroup {
 
   /** runs ClimbSequence but adds the layer that if the robot is interrupted, then everything is brought to the prep state */
   public static Command interruptibleClimbSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
-    return new ClimbSequence(intake, elevator, shooter, conveyor)
+    return new ClimbSequence(intake, elevator, conveyor, shooter)
         .finallyDo(
             (boolean interrupted) -> {
               PrepClimbSequence.interruptiblePrepClimbSequence(intake, elevator, conveyor, shooter);

--- a/src/main/java/frc/robot/commands/GoHomeSequence.java
+++ b/src/main/java/frc/robot/commands/GoHomeSequence.java
@@ -4,17 +4,19 @@ import edu.wpi.first.wpilibj2.command.ConditionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
+import frc.robot.subsystems.conveyor.Conveyor;
 import frc.robot.subsystems.elevator.Elevator;
 import frc.robot.subsystems.elevator.Elevator.ElevatorPosition;
 import frc.robot.subsystems.intake.Intake;
 import frc.robot.subsystems.intake.Intake.IntakePosition;
+import frc.robot.subsystems.shooter.Shooter;
 
 /**
  * brings the elevator and intake to their respective home positions in a "smart" way so they do not
  * end up attacking each other accidentally
  */
 public class GoHomeSequence extends SequentialCommandGroup {
-  public GoHomeSequence(Intake intake, Elevator elevator) {
+  public GoHomeSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
     final SequentialCommandGroup goHomeWhenSafe =
         new SequentialCommandGroup(
             new InstantCommand(() -> intake.setDesiredIntakePosition(IntakePosition.STOWED)),

--- a/src/main/java/frc/robot/commands/IntakeSequence.java
+++ b/src/main/java/frc/robot/commands/IntakeSequence.java
@@ -1,5 +1,6 @@
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.ConditionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
@@ -9,6 +10,7 @@ import frc.robot.subsystems.elevator.Elevator;
 import frc.robot.subsystems.elevator.Elevator.ElevatorPosition;
 import frc.robot.subsystems.intake.Intake;
 import frc.robot.subsystems.intake.Intake.IntakePosition;
+import frc.robot.subsystems.shooter.Shooter;
 
 /**
  * Puts the intake into the deployed position then gets elevator to home position Checks that
@@ -40,5 +42,14 @@ public class IntakeSequence extends SequentialCommandGroup {
             },
             intake),
         new InstantCommand(() -> intake.setDesiredIntakePosition(IntakePosition.STOWED)));
+  }
+
+  /** runs IntakeSequence but adds the layer that if the robot is interrupted, then everything is brought back to the home state */
+  public static Command interruptibleIntakeSequnce(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
+    return new IntakeSequence(intake, elevator, conveyor)
+        .finallyDo(
+            (boolean interrupted) -> {
+              new StopMostThings(intake, elevator, conveyor, shooter);
+            });
   }
 }

--- a/src/main/java/frc/robot/commands/IntakeSequence.java
+++ b/src/main/java/frc/robot/commands/IntakeSequence.java
@@ -18,7 +18,7 @@ import frc.robot.subsystems.shooter.Shooter;
  * game piece Stops and stowes intake
  */
 public class IntakeSequence extends SequentialCommandGroup {
-  public IntakeSequence(Intake intake, Elevator elevator, Conveyor conveyor) {
+  public IntakeSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
     addRequirements(intake, elevator, conveyor);
 
     addCommands(
@@ -46,7 +46,7 @@ public class IntakeSequence extends SequentialCommandGroup {
 
   /** runs IntakeSequence but adds the layer that if the robot is interrupted, then everything is brought back to the home state */
   public static Command interruptibleIntakeSequnce(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
-    return new IntakeSequence(intake, elevator, conveyor)
+    return new IntakeSequence(intake, elevator, conveyor, shooter)
         .finallyDo(
             (boolean interrupted) -> {
               new StopMostThings(intake, elevator, conveyor, shooter);

--- a/src/main/java/frc/robot/commands/PrepClimbSequence.java
+++ b/src/main/java/frc/robot/commands/PrepClimbSequence.java
@@ -1,9 +1,11 @@
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.ConditionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
+import frc.robot.subsystems.conveyor.Conveyor;
 import frc.robot.subsystems.elevator.Elevator;
 import frc.robot.subsystems.elevator.Elevator.ElevatorPosition;
 import frc.robot.subsystems.intake.Intake;
@@ -26,5 +28,14 @@ public class PrepClimbSequence extends SequentialCommandGroup {
             elevator::elevatorAboveInterferenceZone),
         new InstantCommand(() -> elevator.setDesiredPosition(ElevatorPosition.PRE_CLIMB)),
         new InstantCommand(() -> shooter.setShooterMode(ShooterMode.PRELATCH)));
+  }
+
+  /** runs PrepClimbSequence but adds the layer that if the robot is interrupted, then everything is brought back to the home state */
+  public static Command interruptiblePrepClimbSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
+    return new PrepClimbSequence(intake, elevator, shooter)
+        .finallyDo(
+            (boolean interrupted) -> {
+              new StopMostThings(intake, elevator, conveyor, shooter);
+            });
   }
 }

--- a/src/main/java/frc/robot/commands/PrepClimbSequence.java
+++ b/src/main/java/frc/robot/commands/PrepClimbSequence.java
@@ -18,7 +18,7 @@ import frc.robot.subsystems.shooter.Shooter.ShooterMode;
  * positions
  */
 public class PrepClimbSequence extends SequentialCommandGroup {
-  public PrepClimbSequence(Intake intake, Elevator elevator, Shooter shooter) {
+  public PrepClimbSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
     addRequirements(intake, elevator, shooter);
     addCommands(
         new InstantCommand(() -> intake.setDesiredIntakePosition(IntakePosition.DEPLOYED)),
@@ -32,7 +32,7 @@ public class PrepClimbSequence extends SequentialCommandGroup {
 
   /** runs PrepClimbSequence but adds the layer that if the robot is interrupted, then everything is brought back to the home state */
   public static Command interruptiblePrepClimbSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
-    return new PrepClimbSequence(intake, elevator, shooter)
+    return new PrepClimbSequence(intake, elevator, conveyor, shooter)
         .finallyDo(
             (boolean interrupted) -> {
               new StopMostThings(intake, elevator, conveyor, shooter);

--- a/src/main/java/frc/robot/commands/SpeakerPrepScoreSequence.java
+++ b/src/main/java/frc/robot/commands/SpeakerPrepScoreSequence.java
@@ -17,17 +17,17 @@ public class SpeakerPrepScoreSequence extends SequentialCommandGroup {
   /** this is a specified distance from the speaker each time until we do limelight stuff */
   public final double SPEAKER_SHOOTER_DISTANCE_METERS = 5.0;
 
-  public SpeakerPrepScoreSequence(Intake intake, Elevator elevator, Shooter shooter) {
+  public SpeakerPrepScoreSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
     addRequirements(intake, elevator, shooter);
     addCommands(
         new InstantCommand(() -> shooter.setShooterDistance(SPEAKER_SHOOTER_DISTANCE_METERS)),
         new InstantCommand(() -> shooter.setShooterMode(ShooterMode.SHOOT)),
-        new GoHomeSequence(intake, elevator));
+        new GoHomeSequence(intake, elevator, conveyor, shooter));
   }
 
   /** runs SpeakerPrepScoreSequence but adds the layer that if the robot is interrupted, then everything is brought back to the home state */
   public static Command interruptibleSpeakerPrepScoreSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
-    return new SpeakerPrepScoreSequence(intake, elevator, shooter)
+    return new SpeakerPrepScoreSequence(intake, elevator, conveyor, shooter)
         .finallyDo(
             (boolean interrupted) -> {
               new StopMostThings(intake, elevator, conveyor, shooter);

--- a/src/main/java/frc/robot/commands/SpeakerPrepScoreSequence.java
+++ b/src/main/java/frc/robot/commands/SpeakerPrepScoreSequence.java
@@ -1,7 +1,9 @@
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import frc.robot.subsystems.conveyor.Conveyor;
 import frc.robot.subsystems.elevator.Elevator;
 import frc.robot.subsystems.intake.Intake;
 import frc.robot.subsystems.shooter.Shooter;
@@ -21,5 +23,14 @@ public class SpeakerPrepScoreSequence extends SequentialCommandGroup {
         new InstantCommand(() -> shooter.setShooterDistance(SPEAKER_SHOOTER_DISTANCE_METERS)),
         new InstantCommand(() -> shooter.setShooterMode(ShooterMode.SHOOT)),
         new GoHomeSequence(intake, elevator));
+  }
+
+  /** runs SpeakerPrepScoreSequence but adds the layer that if the robot is interrupted, then everything is brought back to the home state */
+  public static Command interruptibleSpeakerPrepScoreSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
+    return new SpeakerPrepScoreSequence(intake, elevator, shooter)
+        .finallyDo(
+            (boolean interrupted) -> {
+              new StopMostThings(intake, elevator, conveyor, shooter);
+            });
   }
 }

--- a/src/main/java/frc/robot/commands/SpeakerShootSequence.java
+++ b/src/main/java/frc/robot/commands/SpeakerShootSequence.java
@@ -1,9 +1,12 @@
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
 import frc.robot.subsystems.conveyor.Conveyor;
+import frc.robot.subsystems.elevator.Elevator;
+import frc.robot.subsystems.intake.Intake;
 import frc.robot.subsystems.shooter.Shooter;
 import frc.robot.subsystems.shooter.Shooter.ShooterMode;
 
@@ -21,5 +24,14 @@ public class SpeakerShootSequence extends SequentialCommandGroup {
             }),
         Conveyor.shoot(conveyor),
         new InstantCommand(() -> shooter.setShooterMode(ShooterMode.IDLE)));
+  }
+
+  /** runs SpeakerShootSequence but adds the layer that if the robot is interrupted, then everything is brought to the prep state */
+  public static Command interruptibleSpeakerShootSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
+    return new SpeakerShootSequence(conveyor, shooter)
+        .finallyDo(
+            (boolean interrupted) -> {
+              SpeakerPrepScoreSequence.interruptibleSpeakerPrepScoreSequence(intake, elevator, conveyor, shooter);
+            });
   }
 }

--- a/src/main/java/frc/robot/commands/SpeakerShootSequence.java
+++ b/src/main/java/frc/robot/commands/SpeakerShootSequence.java
@@ -15,7 +15,7 @@ import frc.robot.subsystems.shooter.Shooter.ShooterMode;
  * back to rest. this assumes that the robot is already prepared to shoot
  */
 public class SpeakerShootSequence extends SequentialCommandGroup {
-  public SpeakerShootSequence(Conveyor conveyor, Shooter shooter) {
+  public SpeakerShootSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
     addRequirements(conveyor, shooter);
     addCommands(
         new WaitUntilCommand(
@@ -28,7 +28,7 @@ public class SpeakerShootSequence extends SequentialCommandGroup {
 
   /** runs SpeakerShootSequence but adds the layer that if the robot is interrupted, then everything is brought to the prep state */
   public static Command interruptibleSpeakerShootSequence(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
-    return new SpeakerShootSequence(conveyor, shooter)
+    return new SpeakerShootSequence(intake, elevator, conveyor, shooter)
         .finallyDo(
             (boolean interrupted) -> {
               SpeakerPrepScoreSequence.interruptibleSpeakerPrepScoreSequence(intake, elevator, conveyor, shooter);

--- a/src/main/java/frc/robot/commands/StopMostThings.java
+++ b/src/main/java/frc/robot/commands/StopMostThings.java
@@ -18,6 +18,6 @@ public class StopMostThings extends SequentialCommandGroup {
         new InstantCommand(() -> shooter.setShooterMode(ShooterMode.IDLE)),
         Conveyor.stop(conveyor),
         new InstantCommand(intake::stopRollers),
-        new GoHomeSequence(intake, elevator));
+        new GoHomeSequence(intake, elevator, conveyor, shooter));
   }
 }

--- a/src/main/java/frc/robot/commands/StopMostThings.java
+++ b/src/main/java/frc/robot/commands/StopMostThings.java
@@ -1,0 +1,23 @@
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import frc.robot.subsystems.conveyor.Conveyor;
+import frc.robot.subsystems.elevator.Elevator;
+import frc.robot.subsystems.intake.Intake;
+import frc.robot.subsystems.shooter.Shooter;
+import frc.robot.subsystems.shooter.Shooter.ShooterMode;
+
+/** returns the robot to a home state without anything moving or shooting
+ * should run when the HOME button is pressed
+ */
+public class StopMostThings extends SequentialCommandGroup {
+  public StopMostThings(Intake intake, Elevator elevator, Conveyor conveyor, Shooter shooter) {
+    addRequirements(intake, elevator, conveyor, shooter);
+    addCommands(
+        new InstantCommand(() -> shooter.setShooterMode(ShooterMode.IDLE)),
+        Conveyor.stop(conveyor),
+        new InstantCommand(intake::stopRollers),
+        new GoHomeSequence(intake, elevator));
+  }
+}

--- a/src/main/java/frc/robot/subsystems/conveyor/Conveyor.java
+++ b/src/main/java/frc/robot/subsystems/conveyor/Conveyor.java
@@ -156,7 +156,7 @@ public class Conveyor extends SubsystemBase {
   }
 
   /** Stop the conveor rollers. */
-  private static Command stop(Conveyor conveyor) {
+  public static Command stop(Conveyor conveyor) {
     return new InstantCommand(conveyor::stopRollers, conveyor);
   }
 


### PR DESCRIPTION
- creates a StopMostThings.java class that brings the robot to the "home" state (stops the conveyor, the shooter, and the intake rollers; brings the intake to STOWED and elevator to HOME)
- adds an "interruptible" version of each command group
          - if the command group is a "prep," then interrupting the command will bring the robot to the "home" state
          - if the command group is not a "prep," then interrupting the command will bring the robot to the command's interruptible "prep" state