### PR TITLE
Switched CanSparksMax to Coast when Disabled

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -55,13 +55,10 @@ public class Robot extends TimedRobot {
   /** This function is called once each time the robot enters disabled mode. */
   @Override
   public void disabledInit() {
-    if (m_autonomousCommand != null) {
-      m_autonomousCommand.cancel();
-    }
     LimelightHelpers.getLatestResults(
         IntakeLimelightConstants.INTAKE_LIMELIGHT_NAME); // It takes 2.5-3s on first run
 
-    if (m_robotContainer.matchState.realMatch) {
+    if (!m_robotContainer.matchState.realMatch) {
       m_robotContainer.intake.pivotMotor.setIdleMode(IdleMode.kCoast);
       m_robotContainer.elevator.leftMotor.setIdleMode(IdleMode.kCoast);
       m_robotContainer.elevator.rightMotor.setIdleMode(IdleMode.kCoast);

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -65,10 +65,6 @@ public class Robot extends TimedRobot {
       m_robotContainer.intake.pivotMotor.setIdleMode(IdleMode.kCoast);
       m_robotContainer.elevator.leftMotor.setIdleMode(IdleMode.kCoast);
       m_robotContainer.elevator.rightMotor.setIdleMode(IdleMode.kCoast);
-      m_robotContainer.conveyor.frontMotor.setIdleMode(IdleMode.kCoast);
-      m_robotContainer.conveyor.backMotor.setIdleMode(IdleMode.kCoast);
-      m_robotContainer.shooter.motorA.setIdleMode(IdleMode.kCoast);
-      m_robotContainer.shooter.motorB.setIdleMode(IdleMode.kCoast);
       m_robotContainer.shooter.pivotMotor.setIdleMode(IdleMode.kCoast);
       m_robotContainer.drive.frontRight.turningSparkMax.setIdleMode(IdleMode.kCoast);
       m_robotContainer.drive.frontLeft.turningSparkMax.setIdleMode(IdleMode.kCoast);
@@ -91,6 +87,17 @@ public class Robot extends TimedRobot {
     }
 
     setRobotContainerMatchState();
+
+    if (m_robotContainer.matchState.realMatch) {
+      m_robotContainer.intake.pivotMotor.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.elevator.leftMotor.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.elevator.rightMotor.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.shooter.pivotMotor.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.drive.frontRight.turningSparkMax.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.drive.frontLeft.turningSparkMax.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.drive.rearRight.turningSparkMax.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.drive.rearLeft.turningSparkMax.setIdleMode(IdleMode.kBrake);
+    }
   }
 
   /** This function is called periodically during autonomous. */
@@ -108,6 +115,17 @@ public class Robot extends TimedRobot {
     }
 
     setRobotContainerMatchState();
+
+    if (m_robotContainer.matchState.realMatch) {
+      m_robotContainer.intake.pivotMotor.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.elevator.leftMotor.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.elevator.rightMotor.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.shooter.pivotMotor.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.drive.frontRight.turningSparkMax.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.drive.frontLeft.turningSparkMax.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.drive.rearRight.turningSparkMax.setIdleMode(IdleMode.kBrake);
+      m_robotContainer.drive.rearLeft.turningSparkMax.setIdleMode(IdleMode.kBrake);
+    }
   }
 
   /** This function is called periodically during operator control. */

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -5,17 +5,12 @@
 package frc.robot;
 
 import com.revrobotics.CANSparkBase.IdleMode;
-
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import frc.robot.subsystems.conveyor.Conveyor;
-import frc.robot.subsystems.elevator.Elevator;
-import frc.robot.subsystems.intake.Intake;
 import frc.robot.subsystems.intakeLimelight.IntakeLimelightConstants;
-import frc.robot.subsystems.shooter.Shooter;
 import frc.robot.utils.LimelightHelpers;
 
 /**

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,12 +4,18 @@
 
 package frc.robot;
 
+import com.revrobotics.CANSparkBase.IdleMode;
+
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.subsystems.conveyor.Conveyor;
+import frc.robot.subsystems.elevator.Elevator;
+import frc.robot.subsystems.intake.Intake;
 import frc.robot.subsystems.intakeLimelight.IntakeLimelightConstants;
+import frc.robot.subsystems.shooter.Shooter;
 import frc.robot.utils.LimelightHelpers;
 
 /**
@@ -51,11 +57,29 @@ public class Robot extends TimedRobot {
     CommandScheduler.getInstance().run();
   }
 
-  /** This function is called once each time the robot enters Disabled mode. */
+  /** This function is called once each time the robot enters disabled mode. */
   @Override
   public void disabledInit() {
+    if (m_autonomousCommand != null) {
+      m_autonomousCommand.cancel();
+    }
     LimelightHelpers.getLatestResults(
         IntakeLimelightConstants.INTAKE_LIMELIGHT_NAME); // It takes 2.5-3s on first run
+
+    if (m_robotContainer.matchState.realMatch) {
+      m_robotContainer.intake.pivotMotor.setIdleMode(IdleMode.kCoast);
+      m_robotContainer.elevator.leftMotor.setIdleMode(IdleMode.kCoast);
+      m_robotContainer.elevator.rightMotor.setIdleMode(IdleMode.kCoast);
+      m_robotContainer.conveyor.frontMotor.setIdleMode(IdleMode.kCoast);
+      m_robotContainer.conveyor.backMotor.setIdleMode(IdleMode.kCoast);
+      m_robotContainer.shooter.motorA.setIdleMode(IdleMode.kCoast);
+      m_robotContainer.shooter.motorB.setIdleMode(IdleMode.kCoast);
+      m_robotContainer.shooter.pivotMotor.setIdleMode(IdleMode.kCoast);
+      m_robotContainer.drive.frontRight.turningSparkMax.setIdleMode(IdleMode.kCoast);
+      m_robotContainer.drive.frontLeft.turningSparkMax.setIdleMode(IdleMode.kCoast);
+      m_robotContainer.drive.rearRight.turningSparkMax.setIdleMode(IdleMode.kCoast);
+      m_robotContainer.drive.rearLeft.turningSparkMax.setIdleMode(IdleMode.kCoast);
+    }
   }
 
   @Override

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -48,11 +48,11 @@ public class RobotContainer {
   private final CommandXboxController driverController =
       new CommandXboxController(OperatorConstants.driverControllerPort);
 
-  private DriveSubsystem drive;
-  private Intake intake;
-  private Elevator elevator;
-  private Shooter shooter;
-  private Conveyor conveyor;
+  public DriveSubsystem drive;
+  public Intake intake;
+  public Elevator elevator;
+  public Shooter shooter;
+  public Conveyor conveyor;
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {

--- a/src/main/java/frc/robot/subsystems/conveyor/Conveyor.java
+++ b/src/main/java/frc/robot/subsystems/conveyor/Conveyor.java
@@ -16,9 +16,9 @@ import frc.robot.RobotMap;
 import frc.robot.utils.SparkMaxUtils;
 
 public class Conveyor extends SubsystemBase {
-  private CANSparkMax frontMotor =
+  public CANSparkMax frontMotor =
       new CANSparkMax(RobotMap.FRONT_CONVEYOR_CAN_ID, MotorType.kBrushless);
-  private CANSparkMax backMotor =
+  public CANSparkMax backMotor =
       new CANSparkMax(RobotMap.BACK_CONVEYOR_CAN_ID, MotorType.kBrushless);
 
   /** Configured to read inches, positive towards the shooter. */

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -27,7 +27,7 @@ import java.util.TreeMap;
 /** Intake pivot and rollers. */
 public class Intake extends SubsystemBase {
 
-  private final CANSparkMax pivotMotor =
+  public final CANSparkMax pivotMotor =
       new CANSparkMax(RobotMap.INTAKE_PIVOT_MOTOR_CAN_ID, MotorType.kBrushless);
   /** Configured to read degrees, zero is down. */
   private final AbsoluteEncoder pivotAbsoluteEncoder =

--- a/src/main/java/frc/robot/subsystems/shooter/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Shooter.java
@@ -42,7 +42,7 @@ public class Shooter extends SubsystemBase {
       new CANSparkMax(RobotMap.SHOOTER_MOTOR_LEFT_ONE_CAN_ID, MotorType.kBrushless);
   private final CANSparkMax motorLeftTwo =
       new CANSparkMax(RobotMap.SHOOTER_MOTOR_LEFT_TWO_CAN_ID, MotorType.kBrushless);
-  private final CANSparkMax pivotMotor =
+  public final CANSparkMax pivotMotor =
       new CANSparkMax(RobotMap.SHOOTER_PIVOT_MOTOR_CAN_ID, MotorType.kBrushless);
   /** Configured to read degrees, zero is shooting straight down */
   private final AbsoluteEncoder pivotMotorAbsoluteEncoder =


### PR DESCRIPTION
- made all CanSparksMax instance variables public
- made instances of subsystems in RobotContainer
- set each CanSparksMax instances in Robot to coast when disabled, after determining that we are in a real match