### PR TITLE
Fixes from 02/18

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -71,7 +71,10 @@ public class Robot extends TimedRobot {
   }
 
   @Override
-  public void disabledPeriodic() {}
+  public void disabledPeriodic() {
+    m_robotContainer.shooter.considerZeroingEncoder();
+    m_robotContainer.intake.considerZeroingEncoder();
+  }
 
   /** This autonomous runs the autonomous command selected by your {@link RobotContainer} class. */
   @Override

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,8 +4,12 @@
 
 package frc.robot;
 
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Constants.OperatorConstants;
@@ -14,6 +18,7 @@ import frc.robot.subsystems.drive.DriveSubsystem;
 import frc.robot.subsystems.elevator.Elevator;
 import frc.robot.subsystems.intake.Intake;
 import frc.robot.subsystems.shooter.Shooter;
+import frc.robot.utils.JoystickUtil;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -56,6 +61,7 @@ public class RobotContainer {
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
+    // Add subsystems
     drive = new DriveSubsystem(matchState);
     intake = new Intake();
     elevator = new Elevator();
@@ -64,6 +70,14 @@ public class RobotContainer {
 
     // Configure the trigger bindings
     configureBindings();
+
+    Shuffleboard.getTab("Subsystems").add(drive.getName(), drive);
+    Shuffleboard.getTab("Subsystems").add(intake.getName(), intake);
+    Shuffleboard.getTab("Subsystems").add(conveyor.getName(), conveyor);
+    Shuffleboard.getTab("Subsystems").add(shooter.getName(), shooter);
+    Shuffleboard.getTab("Subsystems").add(elevator.getName(), elevator);
+
+    burnFlashAllSparks();
   }
 
   /**
@@ -76,6 +90,16 @@ public class RobotContainer {
    * joysticks}.
    */
   private void configureBindings() {}
+
+  private void burnFlashAllSparks() {
+    Timer.delay(0.25);
+    drive.burnFlashSparks();
+    intake.burnFlashSpark();
+    conveyor.burnFlashSparks();
+    elevator.burnFlashSparks();
+    shooter.burnFlashSparks();
+    Timer.delay(0.25);
+  }
 
   /**
    * Use this to pass the autonomous command to the main {@link Robot} class.

--- a/src/main/java/frc/robot/subsystems/conveyor/ConveyorConstants.java
+++ b/src/main/java/frc/robot/subsystems/conveyor/ConveyorConstants.java
@@ -1,13 +1,11 @@
 package frc.robot.subsystems.conveyor;
 
-import frc.robot.Constants;
-
 public class ConveyorConstants {
   public static final boolean FRONT_MOTOR_INVERTED = false, BACK_MOTOR_INVERTED = false;
 
   /** Gear ratios for the rollers */
-  public static final double FRONT_GEAR_RATIO = Constants.PLACEHOLDER_DOUBLE,
-      BACK_GEAR_RATIO = Constants.PLACEHOLDER_DOUBLE;
+  public static final double FRONT_GEAR_RATIO = 8.4,
+      BACK_GEAR_RATIO = 8.4;
 
   public static final double CONVEYOR_MOTOR_ROLLER_DIAMETER_IN = 1.1;
 }

--- a/src/main/java/frc/robot/subsystems/elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/elevator/Elevator.java
@@ -90,16 +90,6 @@ public class Elevator extends SubsystemBase {
 
     errors += SparkMaxUtils.check(rightMotor.follow(leftMotor, true));
 
-    errors +=
-        SparkMaxUtils.check(
-            leftMotor.setSoftLimit(
-                SoftLimitDirection.kForward, ElevatorCal.ELEVATOR_POSITIVE_LIMIT_INCHES));
-    errors += SparkMaxUtils.check(leftMotor.enableSoftLimit(SoftLimitDirection.kForward, true));
-    errors +=
-        SparkMaxUtils.check(
-            leftMotor.setSoftLimit(
-                SoftLimitDirection.kReverse, ElevatorCal.ELEVATOR_NEGATIVE_LIMIT_INCHES));
-    errors += SparkMaxUtils.check(leftMotor.enableSoftLimit(SoftLimitDirection.kReverse, true));
 
     errors += SparkMaxUtils.check(leftMotor.setIdleMode(IdleMode.kBrake));
     errors += SparkMaxUtils.check(rightMotor.setIdleMode(IdleMode.kBrake));

--- a/src/main/java/frc/robot/subsystems/intake/IntakeCal.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeCal.java
@@ -6,13 +6,16 @@ import frc.robot.Constants;
 public class IntakeCal {
 
   /** PID values for the intake pivot motor input degrees, output volts */
-  public static final double INTAKE_PIVOT_P = Constants.PLACEHOLDER_DOUBLE,
+  public static final double INTAKE_PIVOT_P = 0.2,
       INTAKE_PIVOT_I = Constants.PLACEHOLDER_DOUBLE,
       INTAKE_PIVOT_D = Constants.PLACEHOLDER_DOUBLE;
 
   /** Motion profile max velocity and acceleration (deg per second) for intake pivot motor */
-  public static final double PIVOT_MAX_VELOCITY_DEG_PER_SECOND = 30.0,
-      PIVOT_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED = 30.0;
+  public static final double PIVOT_MAX_VELOCITY_DEG_PER_SECOND = 120.0,
+      PIVOT_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED = 120.0;
+
+  public static final double PIVOT_ENCODER_ZEROING_THRESHOLD = 5.0;
+  public static final double PIVOT_PROFILE_REPLANNING_THRESHOLD = 20.0;
 
   /**
    * intake positions (degrees) where 90 degrees represents the intake at the shooter and 0 degrees
@@ -27,20 +30,31 @@ public class IntakeCal {
   public static final double CONVEYOR_ZONE_THRESHOLD_DEGREES = 190.0;
 
   /** intake power [-1.0,1.0] */
-  public static final double INTAKING_POWER = 1.0, REVERSE_INTAKING_POWER = -1.0;
+  public static final double INTAKING_POWER = 0.6, REVERSE_INTAKING_POWER = -0.6;
 
   /* input degrees, output volts
    * https://www.reca.lc/arm?armMass=%7B%22s%22%3A15%2C%22u%22%3A%22lbs%22%7D&comLength=%7B%22s%22%3A14%2C%22u%22%3A%22in%22%7D&currentLimit=%7B%22s%22%3A50%2C%22u%22%3A%22A%22%7D&efficiency=85&endAngle=%7B%22s%22%3A50%2C%22u%22%3A%22deg%22%7D&iterationLimit=10000&motor=%7B%22quantity%22%3A1%2C%22name%22%3A%22NEO%22%7D&ratio=%7B%22magnitude%22%3A97%2C%22ratioType%22%3A%22Reduction%22%7D&startAngle=%7B%22s%22%3A0%2C%22u%22%3A%22deg%22%7D
    */
   public static final SimpleMotorFeedforward INTAKE_PIVOT_FEEDFORWARD =
-      new SimpleMotorFeedforward(0.0, 0.033, 0.00070);
+      new SimpleMotorFeedforward(0.4, 0.033, 0.00070);
 
   /** Voltage needed to hold the pivot up when it's horizontal */
-  public static final double ARBITRARY_INTAKE_PIVOT_FEEDFORWARD_VOLTS = 0.76;
+  public static final double ARBITRARY_INTAKE_PIVOT_FEEDFORWARD_VOLTS = 1.0;
 
-  /** Offset degrees for intake absolute encoder */
-  public static final double INTAKE_ABSOLUTE_ENCODER_ZERO_OFFSET_DEG = Constants.PLACEHOLDER_DOUBLE;
+  /** Offset degrees for intake absolute encoder.
+   * Real world degrees minus what the encoder read at that position.
+  */
+  public static final double INTAKE_ABSOLUTE_ENCODER_ZERO_OFFSET_DEG = 155.4 - 56.89;
 
-  public static final int PIVOT_MOTOR_CURRENT_LIMIT_AMPS = 25;
+  /** The absolute encoder wraps every 120 degrees. At most stowed,
+   * it will read 5-10 degrees higher than at most deployed
+   * (actually 110-115 deg lower).
+   * For positions at most deployed, the real value is 120 deg greater due to wrap.
+   * This value is between the readings at the max travel in each direction.
+   * If the reading is above vs. below, this indicates whether 120 deg needs to be added to the reading.
+   */
+  public static final double INTAKE_ABSOLUTE_ENCODER_WRAP_POINT_DEG = 55.0;
+
+  public static final int PIVOT_MOTOR_CURRENT_LIMIT_AMPS = 50;
   public static final double INTAKING_TALONS_CURRENT_LIMIT_AMPS = 50.0;
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeConstants.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeConstants.java
@@ -2,8 +2,11 @@ package frc.robot.subsystems.intake;
 
 public class IntakeConstants {
   /** TODO double check this */
-  public static final double INTAKE_POSITION_WHEN_HORIZONTAL_DEGREES = 90.0;
+  public static final double INTAKE_POSITION_WHEN_HORIZONTAL_DEGREES = 70.0;
 
   public static final double INPUT_ABS_ENCODER_GEAR_RATIO = 3.0;
+  public static final double INPUT_ABS_ENCODER_WRAP_INCREMENT_DEGREES = 360.0 / INPUT_ABS_ENCODER_GEAR_RATIO;
   public static final double INTAKING_TIMEOUT_SEC = 7.5; // TODO check this
+
+  public static final double PIVOT_MOTOR_GEAR_RATIO = 97.06;
 }

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterCal.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterCal.java
@@ -16,15 +16,16 @@ public class ShooterCal {
       MOTOR_B_kFF = Constants.PLACEHOLDER_DOUBLE;
 
   /** Pivot Motor PID, Unit Inputs: Degrees. output Volts */
-  public static final double PIVOT_MOTOR_kP = Constants.PLACEHOLDER_DOUBLE,
+  public static final double PIVOT_MOTOR_kP = 0.2,
       PIVOT_MOTOR_kI = Constants.PLACEHOLDER_DOUBLE,
-      PIVOT_MOTOR_kD = Constants.PLACEHOLDER_DOUBLE;
+      PIVOT_MOTOR_kD = 0.01;
+
 
   /**
    * Pivot Motor Feedforward. Inputs: Degrees. output Volts.
    * https://www.reca.lc/arm?armMass=%7B%22s%22%3A20%2C%22u%22%3A%22lbs%22%7D&comLength=%7B%22s%22%3A5%2C%22u%22%3A%22in%22%7D&currentLimit=%7B%22s%22%3A50%2C%22u%22%3A%22A%22%7D&efficiency=85&endAngle=%7B%22s%22%3A30%2C%22u%22%3A%22deg%22%7D&iterationLimit=10000&motor=%7B%22quantity%22%3A1%2C%22name%22%3A%22NEO%22%7D&ratio=%7B%22magnitude%22%3A127.5%2C%22ratioType%22%3A%22Reduction%22%7D&startAngle=%7B%22s%22%3A0%2C%22u%22%3A%22deg%22%7D
    */
-  public static final double PIVOT_MOTOR_KS = 0.0,
+  public static final double PIVOT_MOTOR_KS = 0.1,
       PIVOT_MOTOR_KV = 0.043,
       PIVOT_MOTOR_KA = 0.000083;
 
@@ -39,13 +40,20 @@ public class ShooterCal {
   public static final double SHOOTER_SPEED_MARGIN_RPM = 40.0;
 
   /** Motion profile constraints for the pivot. */
-  public static final double PIVOT_MAX_VELOCITY_DEG_PER_SECOND = 30.0,
-      PIVOT_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED = 30.0;
+  public static final double PIVOT_MAX_VELOCITY_DEG_PER_SECOND = 200.0,
+      PIVOT_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED = 480.0;
+
+  public static final double PIVOT_PROFILE_REPLANNING_THRESHOLD = 5.0;
+  public static final double PIVOT_ENCODER_ZEROING_THRESHOLD = 5.0;
 
   /** Pivot motor voltage to hold the pivot in place at */
-  public static final double ARBITRARY_PIVOT_FEED_FORWARD_VOLTS = 0.28;
+  public static final double PIVOT_GRAVITY_FEED_FORWARD_VOLTS = 0.28;
+
+  /** Pivot motor arbitrary voltage in direction of position error */
+  public static final double PIVOT_POS_FEED_FORWARD_VOLTS = 0.1;
 
   public static final int SHOOTER_CURRENT_LIMIT_AMPS = 50;
+  public static final int PIVOT_CURRENT_LIMIT_AMPS = 50;
 
   /** Pivot position for latching onto the chain */
   public static final double LATCH_ANGLE_DEGREES = 110.0;
@@ -62,7 +70,7 @@ public class ShooterCal {
    * What the abs encoder reads (in degrees) when the shooter is pointed down. Acquired by pointing
    * the encoder at 90 and subtracting 90 from that reading.
    */
-  public static final double PIVOT_ANGLE_OFFSET_DEGREES = Constants.PLACEHOLDER_DOUBLE;
+  public static final double PIVOT_ANGLE_OFFSET_DEGREES = 39.5 - 90.0;
 
   /** Position at which (or beyond) the shooter has potential to intersect the conveyor. */
   public static final double CONVEYOR_ZONE_THRESHOLD_DEGREES = Constants.PLACEHOLDER_DOUBLE;

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterConstants.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterConstants.java
@@ -5,5 +5,8 @@ public class ShooterConstants {
   public static final double POSITION_WHEN_HORIZONTAL_DEGREES = 90.0;
 
   /** Ratio of encoder rotations to mechanism rotations */
+  public static final double PIVOT_MOTOR_GEAR_RATIO = 127.5;
+
+  /** Ratio of encoder rotations to mechanism rotations */
   public static final double ABS_ENCODER_GEAR_RATIO = 2.0;
 }

--- a/src/main/java/frc/robot/utils/JoystickUtil.java
+++ b/src/main/java/frc/robot/utils/JoystickUtil.java
@@ -1,0 +1,7 @@
+package frc.robot.utils;
+
+public class JoystickUtil {
+  public static double squareAxis(double input) {
+    return (input * input) * Math.signum(input);
+  }
+}

--- a/src/main/java/frc/robot/utils/SparkMaxUtils.java
+++ b/src/main/java/frc/robot/utils/SparkMaxUtils.java
@@ -23,27 +23,29 @@ public class SparkMaxUtils {
     public static REVLibError setDegreesFromGearRatio(
         AbsoluteEncoder sparkMaxEncoder, double ratio) {
       double degreesPerRotation = 360.0 / ratio;
-      double degreesPerRotationPerSecond = degreesPerRotation / 60.0;
-      REVLibError error = sparkMaxEncoder.setPositionConversionFactor(degreesPerRotation);
+      REVLibError errorOne = sparkMaxEncoder.setPositionConversionFactor(degreesPerRotation);
+      REVLibError errorTwo = sparkMaxEncoder.setVelocityConversionFactor(degreesPerRotation);
 
-      if (error != REVLibError.kOk) {
-        return error;
+      if (errorOne != REVLibError.kOk) {
+        return errorOne;
+      }
+      if (errorTwo != REVLibError.kOk) {
+        return errorTwo;
       }
 
-      return sparkMaxEncoder.setVelocityConversionFactor(degreesPerRotationPerSecond);
+      return REVLibError.kOk;
     }
 
     /** Sets the encoder to read radians after some gear ratio. */
     public static REVLibError setRadsFromGearRatio(AbsoluteEncoder sparkMaxEncoder, double ratio) {
       double radsPerRotation = (2.0 * Math.PI) / ratio;
-      double radsPerRotationPerSecond = radsPerRotation / 60.0;
       REVLibError error = sparkMaxEncoder.setPositionConversionFactor(radsPerRotation);
 
       if (error != REVLibError.kOk) {
         return error;
       }
 
-      return sparkMaxEncoder.setVelocityConversionFactor(radsPerRotationPerSecond);
+      return sparkMaxEncoder.setVelocityConversionFactor(radsPerRotation);
     }
 
     /**
@@ -57,14 +59,13 @@ public class SparkMaxUtils {
     public static REVLibError setLinearFromGearRatio(
         AbsoluteEncoder sparkMaxEncoder, final double ratio, final double diameter) {
       double linearDistPerRotation = diameter * Math.PI / ratio;
-      double linearDistPerRotationPerSecond = linearDistPerRotation / 60.0;
       REVLibError error = sparkMaxEncoder.setPositionConversionFactor(linearDistPerRotation);
 
       if (error != REVLibError.kOk) {
         return error;
       }
 
-      return sparkMaxEncoder.setVelocityConversionFactor(linearDistPerRotationPerSecond);
+      return sparkMaxEncoder.setVelocityConversionFactor(linearDistPerRotation);
     }
 
     /** Sets the encoder to read degrees after some gear ratio. */


### PR DESCRIPTION
Changes include:
- Zeroing and tuning for the shooter pivot, swapped to use relative encoder while running
- Zeroing and very basic (incomplete) tuning for the intake pivot, swapped to use relative encoder while running
- Add subsystems to shuffleboard
- Call burn flash for all sparks
- Set conveyor gear ratio
- Remove elevator soft limits (we will want to run into the hard stops on both ends)
- Add joystick util for squaring axis while keeping sign
- Fix setting velocity on absolute encoders in util